### PR TITLE
Added in a PoolBuilder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,15 @@ name = "pooled-writer"
 version = "0.2.1-alpha.0"
 edition = "2021"
 authors = [
-    "Seth Stadick <seth@fulcrumgenomics.com>"
+    "Seth Stadick <seth@fulcrumgenomics.com>",
+    "Tim Fennell <tim@fulcrumgenomics.com>"
 ]
 license = "MIT"
 readme = "README.md"
 documentation = "https://docs.rs/pooled-writer"
 homepage = "https://github.com/fulcrumgenomics/pooled-writer"
 repository = "https://github.com/fulcrumgenomics/pooled-writer"
-description = "Utility library for creating M compressed writers over N threads"
+description = "Library for using N threads to write to M compressed files/writers."
 keywords = ["bioinformatics", "genomic", "compression", "writer"]
 categories = ["science", "compression"]
 

--- a/src/bgzf.rs
+++ b/src/bgzf.rs
@@ -7,13 +7,21 @@ pub struct BgzfCompressor {
 }
 
 impl Compressor for BgzfCompressor {
-    type CompressionLevel = bgzf::CompressionLevel;
     type Error = bgzf::BgzfError;
+    type CompressionLevel = bgzf::CompressionLevel;
 
     const BLOCK_SIZE: usize = bgzf::BGZF_BLOCK_SIZE;
 
     fn new(compression_level: Self::CompressionLevel) -> Self {
         Self { inner: bgzf::Compressor::new(compression_level) }
+    }
+
+    fn default_compression_level() -> Self::CompressionLevel {
+        bgzf::CompressionLevel::new(5).unwrap()
+    }
+
+    fn new_compression_level(compression_level: u8) -> Result<Self::CompressionLevel, Self::Error> {
+        bgzf::CompressionLevel::new(compression_level)
     }
 
     fn compress(
@@ -27,9 +35,5 @@ impl Compressor for BgzfCompressor {
             bgzf::Compressor::append_eof(output);
         }
         Ok(())
-    }
-
-    fn new_compression_level(compression_level: u8) -> Result<Self::CompressionLevel, Self::Error> {
-        bgzf::CompressionLevel::new(compression_level)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -679,7 +679,7 @@ mod test {
     use crate::bgzf::BgzfCompressor;
 
     use super::*;
-    use bgzf::Reader;
+    use ::bgzf::Reader;
     use proptest::prelude::*;
     use tempfile::tempdir;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,30 +2,37 @@
 //!
 //! # Overview
 //!
-//! A [`Pool`] is created, started, and writers exchanged for [`PooledWriter`]s all at once in [`Pool::new`].
-//! When creating a pool via [`Pool::new`] two types must be specified: the `W` Writer type and the `C` compressor type.
-//! The `W` may be elided since it's an input. The `C` must be specified as something that implements [`Compressor`].
-//! See `examples/ex1.rs`.
+//! `pooled-writer` solves the problem of compressing and writing data to a set of writers using
+//! multiple threads, where the number of writers and threads cannot easily be equal.  For example
+//! writing to hundreds of gzipped files using 16 threads, or writing to a four gzipped files
+//! using 32 threads.
 //!
-//! The [`Pool`] consists of two threadpools, one for compressing and one for writing. All concurrency
-//! is managed via message passing over channels.
+//! To accomplish this, a pool is configured and writers are exchanged for [`PooledWriter`]s
+//! that can be used in place of the original writers.  This is accomplished using the
+//! [`PoolBuilder`] which is the preferred way to configure and create a pool.  The [`Pool`] and
+//! builder require two generic types: the `W` Writer type and the `C` compressor type. `W` may
+//! usually be elided if calls to [`PoolBuilder::exchange`] may be used to infer the type. `C`
+//! must be specified as something that implements [`Compressor`].
 //!
-//! Every time the internal buffer of a [`PooledWriter`] reaches capacity (defined by [`Compressor::BLOCK_SIZE`])
-//! it sends two messages:
-//! 1. It sends a message over the corresponding writers channel to the writer pool, enqueueing
+//! The [`Pool`] consists of two thread pools, one for compressing and one for writing. All
+//! concurrency is managed via message passing over channels.
+//!
+//! Every time the internal buffer of a [`PooledWriter`] reaches capacity (defined by
+//! [`Compressor::BLOCK_SIZE`]) it sends two messages:
+//! 1. It sends a message over the corresponding writer's channel to the writer pool, enqueueing
 //!    a one-shot receiver channel in the writers queue that will receive the compressed bytes
 //!    once the compressor is done. This is done to maintain the output order.
 //! 2. It sends a message to the compressor pool that contains a buffer of bytes to compress
 //!    as well as the sender side of the one-shot channel to send the compressed bytes on.
 //!
-//! The writer threadpool contains a `Vec` of receivers, one for each writer. It loops over
+//! The writer thread pool contains a `Vec` of receivers, one for each writer. It loops over
 //! this `Vec`, checking to see if the receiver has any messages. If it does, a lock is
 //! acquired and that writer's receiver is drained, writing to the underlying writer that was exchanged
 //! for the [`PooledWriter`].
 //!
-//! The compressor threadpool consists of a single receiver that is continually polled for new
+//! The compressor thread pool consists of a single receiver that is continually polled for new
 //! messages. The messages are processed, the bytes compressed, and then the compressed bytes are
-//! sent over the one-shot channel to the corresponding receiver, which is a place-holder receivers
+//! sent over the one-shot channel to the corresponding receiver, which is a place-holder receiver
 //! in the writer queues.
 //!
 //! Shutdown of the entire pool is managed via a sentinel value that is checked in the writer loop.
@@ -42,7 +49,7 @@
 //!     path::Path,
 //! };
 //!
-//! use pooled_writer::{Compressor, Pool, bgzf::BgzfCompressor};
+//! use pooled_writer::{Compressor, PoolBuilder, Pool, bgzf::BgzfCompressor};
 //!
 //! type DynError = Box<dyn Error + 'static>;
 //!
@@ -52,11 +59,18 @@
 //!
 //! fn main() -> Result<(), DynError> {
 //!     let writers = vec![
-//!         create_writer("./test1.txt.gz")?,
-//!         create_writer("./test2.txt.gz")?,
-//!         create_writer("./test3.txt.gz")?,
+//!         create_writer("/tmp/test1.txt.gz")?,
+//!         create_writer("/tmp/test2.txt.gz")?,
+//!         create_writer("/tmp/test3.txt.gz")?,
 //!     ];
-//!     let (mut pool, mut pooled_writers) = Pool::new::<_, BgzfCompressor>(4, 4, 4, writers)?;
+//!
+//!     let mut builder = PoolBuilder::<_, BgzfCompressor>::new(10, 10)
+//!         .writer_threads(2)
+//!         .compressor_threads(4)
+//!         .compression_level(5)?;
+//!
+//!    let mut pooled_writers = writers.into_iter().map(|w| builder.exchange(w)).collect::<Vec<_>>();
+//!    let mut pool = builder.build()?;
 //!
 //!     writeln!(&mut pooled_writers[1], "This is writer2")?;
 //!     writeln!(&mut pooled_writers[0], "This is writer1")?;
@@ -112,6 +126,10 @@ pub enum PoolError {
     #[error(transparent)]
     Io(#[from] io::Error),
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// The PooledWriter and it's impls
+////////////////////////////////////////////////////////////////////////////////
 
 /// A [`PooledWriter`] is created by exchanging a writer with a [`Pool`].
 ///
@@ -173,7 +191,7 @@ impl PooledWriter {
         C: Compressor,
     {
         Self {
-            compressor_tx: compressor_tx,
+            compressor_tx,
             writer_tx,
             buffer: BytesMut::with_capacity(C::BLOCK_SIZE),
             buffer_size: C::BLOCK_SIZE,
@@ -253,6 +271,10 @@ impl Write for PooledWriter {
     }
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// The Compressor trait
+////////////////////////////////////////////////////////////////////////////////
+
 /// A [`Compressor`] is used in the compressor pool to compress bytes.
 ///
 /// An implementation must be provided as a type to the [`Pool::new`] function so that the pool
@@ -292,6 +314,10 @@ where
     ) -> Result<(), Self::Error>;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// The messages passed between threads
+////////////////////////////////////////////////////////////////////////////////
+
 /// A message that is sent from a [`PooledWriter`] to the compressor threadpool within a [`Pool`].
 #[derive(Debug)]
 struct CompressorMessage {
@@ -320,7 +346,25 @@ struct WriterMessage {
     buffer: Vec<u8>,
 }
 
-/// A struct to make building up a Pool simpler.
+////////////////////////////////////////////////////////////////////////////////
+// The PoolBuilder struct and impls
+////////////////////////////////////////////////////////////////////////////////
+
+/// A struct to make building up a Pool simpler.  The builder should be constructed using
+/// [`PoolBuilder::new`], which provides the user control over the sizes of the queues used for
+/// compression and writing.  It should be noted that a single compression queue is created,
+/// and one writer queue per writer exchanged.  A good starting point for these queue sizes is
+/// two times the number of threads.
+///
+/// Once created various functions can configure aspects of the pool.  It is best practice, though
+/// not required, to configure the builder _before_ exchanging writers.
+///
+/// Once the builder is configured writers may be exchanged for [`PooledWriter`]s using the
+/// [`PoolBuilder::exchange`] function, which consumes the provided writer and returns a new
+/// writer that can be used in it's place.
+///
+/// After exchanging all writers the pool may be created and started with [`PoolBuilder::build`]
+/// which consumes the builder and after which no more writers may be exchanged.
 pub struct PoolBuilder<W, C>
 where
     W: Write + Send + 'static,
@@ -342,7 +386,7 @@ where
     W: Write + Send + 'static,
     C: Compressor,
 {
-    /// Creates a new PoolBuilder that can be used to configure and build a [[Pool]].
+    /// Creates a new PoolBuilder that can be used to configure and build a [`Pool`].
     pub fn new(compressor_queue_size: usize, writer_queues_size: usize) -> Self {
         let (compressor_tx, compressor_rx) = flume::bounded(compressor_queue_size);
 
@@ -360,19 +404,19 @@ where
     }
 
     /// Sets the number of writer threads that will be used by the [[Pool]].
-    pub fn with_writer_threads(mut self, n: usize) -> Self {
+    pub fn writer_threads(mut self, n: usize) -> Self {
         self.writer_threads = n;
         self
     }
 
     /// Sets the number of compressor threads that will be used by the [[Pool]].
-    pub fn with_compressor_threads(mut self, n: usize) -> Self {
+    pub fn compressor_threads(mut self, n: usize) -> Self {
         self.compressor_threads = n;
         self
     }
 
     /// Sets the compression level that will be used by the [[Pool]].
-    pub fn with_compression_level(mut self, level: u8) -> PoolResult<Self> {
+    pub fn compression_level(mut self, level: u8) -> PoolResult<Self> {
         self.compression_level = C::new_compression_level(level)
             .map_err(|e| PoolError::CompressionError(e.to_string()))?;
         Ok(self)
@@ -419,6 +463,10 @@ where
     }
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// The Pool struct and impls
+////////////////////////////////////////////////////////////////////////////////
+
 /// A [`Pool`] orchestrates two different threadpools, a compressor pool and a writer pool.
 ///
 /// The pool is suitable for scenarios where there are many more writers than threads, efficiently
@@ -444,6 +492,7 @@ impl Pool {
     /// - `compression_level` - The compression level to use for the [`Compressor`] pool.
     /// - `writers` - The writers to exchange for [`PooledWriter`]s.
     #[allow(clippy::type_complexity, clippy::similar_names)]
+    #[deprecated(since = "0.3.0", note = "Use PoolBuilder in place of Pool::new().")]
     pub fn new<W, C>(
         num_writer_threads: usize,
         num_compressor_threads: usize,
@@ -454,42 +503,14 @@ impl Pool {
         W: Write + Send + 'static,
         C: Compressor,
     {
-        let compression_level = C::new_compression_level(compression_level)
-            .map_err(|e| PoolError::CompressionError(e.to_string()))?;
-        // Create the channels that the writers will send bytes to be compressed
-        let (compressor_tx, compressor_rx) = flume::bounded(num_compressor_threads * 2);
-        // Create the channel to gracefully signal a shutdown of the pool
-        let (shutdown_tx, shutdown_rx) = flume::unbounded();
+        let mut builder =
+            PoolBuilder::<W, C>::new(num_compressor_threads * 2, num_writer_threads * 2)
+                .compressor_threads(num_compressor_threads)
+                .writer_threads(num_writer_threads)
+                .compression_level(compression_level)?;
 
-        // Create the channels that will enqueue the promise of compressed bytes for the writers
-        let (writers_txs, writers_rxs): (
-            Vec<Sender<Receiver<WriterMessage>>>,
-            Vec<Receiver<Receiver<WriterMessage>>>,
-        ) = (0..writers.len()).map(|_| flume::bounded(num_writer_threads * 2)).unzip();
-
-        // Wrap writers to be pooled writers.
-        let pooled_writers =
-            PooledWriter::from_writers::<W, C>(&writers, &compressor_tx, &writers_txs);
-
-        // Start the pool manager thread and thread pools
-        let handle = std::thread::spawn(move || {
-            Self::pool_main::<W, C>(
-                num_writer_threads,
-                num_compressor_threads,
-                compression_level,
-                compressor_rx,
-                writers_rxs,
-                writers,
-                shutdown_rx,
-            )
-        });
-
-        let mut pool = Self {
-            compressor_tx: Some(compressor_tx),
-            writers_txs: Some(writers_txs),
-            shutdown_tx: Some(shutdown_tx),
-            pool_handle: Some(handle),
-        };
+        let pooled_writers = writers.into_iter().map(|w| builder.exchange(w)).collect();
+        let pool = builder.build()?;
         Ok((pool, pooled_writers))
     }
 
@@ -643,6 +664,10 @@ impl Drop for Pool {
     }
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////////////
+
 #[cfg(test)]
 mod test {
     use std::{
@@ -676,6 +701,7 @@ mod test {
             .collect();
         let output_writers = output_names.iter().map(create_output_writer).collect();
 
+        #[allow(deprecated)]
         let (mut pool, mut pooled_writers) =
             Pool::new::<_, BgzfCompressor>(1, 1, 2, output_writers).unwrap();
 
@@ -704,7 +730,7 @@ mod test {
         let output_writers: Vec<BufWriter<File>> =
             output_names.iter().map(create_output_writer).collect();
         let mut builder =
-            PoolBuilder::<_, BgzfCompressor>::new(10, 10).with_compression_level(2).unwrap();
+            PoolBuilder::<_, BgzfCompressor>::new(10, 10).compression_level(2).unwrap();
         let mut pooled_writers: Vec<PooledWriter> =
             output_writers.into_iter().map(|w| builder.exchange(w)).collect();
         let mut pool = builder.build().unwrap();


### PR DESCRIPTION
I created a `PoolBuilder` which allows for usage like:
1. Create builder
2. Configure builder
3. Exchange writers one at a time for PooledWriters
4. Build the pool

This should be much easier to use when the writers are not naturally in a single Vec or other linear structure (e.g. when they're grouped by samples and file types).

I'm tempted to remove the non-builder way of creating the pool, but thought I'd see what you guys thought first.