### PR TITLE
One pool to rule them all!

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,6 +370,7 @@ where
     C: Compressor,
 {
     /// Creates a new PoolBuilder that can be used to configure and build a [`Pool`].
+    /// The `queue_size` must be greater than the number of `threads`.
     pub fn new(queue_size: usize, threads: usize) -> Self {
         assert!(threads > 0, "Cannot construct a pooled writer with 0 threads");
         assert!(
@@ -500,8 +501,8 @@ impl Pool {
     /// # Arguments
     /// - `num_threads` - The number of threads to use.
     /// - `compression_level` - The compression level to use for the [`Compressor`] pool.
-    /// - `rx_compressor` - The receiving end of the channel for communicating with the compressor pool.
-    /// - `rxs_writers` - The receive halves of the channels for the [`PooledWriter`]s to enqueue the one-shot channels.
+    /// - `compressor_rx ` - The receiving end of the channel for communicating with the compressor pool.
+    /// - `writer_rxs ` - The receive halves of the channels for the [`PooledWriter`]s to enqueue the one-shot channels.
     /// - `writers` - The writers that were exchanged for [`PooledWriter`]s.
     /// - `shutdown_rx` - Sentinel channel to tell the pool management thread to shutdown.
     #[allow(clippy::unnecessary_wraps, clippy::needless_collect, clippy::needless_pass_by_value)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -546,7 +546,6 @@ impl Pool {
                         if !did_something {
                             if shutdown_rx.is_disconnected()
                                 && write_available_rx.is_empty()
-                                && compressor_rx.is_disconnected()
                                 && compressor_rx.is_empty()
                                 && writer_rxs.iter().all(|w| w.is_empty())
                             {
@@ -591,7 +590,6 @@ impl Pool {
         // Drop the copy of the writer senders that the pool holds
         // TODO: the pool probably doesn't need these anyways.
         self.writers_txs.take().into_iter().enumerate().for_each(|(i, w)| {
-            // Wait for writing to finish
             drop(w);
         });
         // Wait on the pool thread to finish and pull any errors from it


### PR DESCRIPTION
An attempt to move the pooled-writer to using a single thread pool instead of one for compressing and one for writing.

Tests pass, including the long prop-test.  However, some cleanup is needed and likely this should be benchmarked against the prior version using real code.

@sstadick Not sure if you're interested in looking at this, but figured you might be interested in how the single-pool solution works.